### PR TITLE
Fix About page link to Home

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ author:
 
 # URL settings
 url: "https://powex.ml" #
-baseurl: "/Gesko" # leave blank if not wishd
+baseurl: "/Gesko/" # leave blank if not wishd
 permalink: "https://powex.ml/Gesko/"
 permalink: pretty 
 


### PR DESCRIPTION
In the About page Home link doesn’t work and get `404 Not Found`:

<img width="808" alt="Screenshot 2021-06-23 at 6 27 41 PM" src="https://user-images.githubusercontent.com/63271146/123081775-e3d82e80-d450-11eb-99a8-7089849cd511.png">
