### PR TITLE
update addressable version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.8)


### PR DESCRIPTION
I updating the addressable version from 2.7.0 to 2.8.0, because in the version 2.7.0 and below have a high risk security namely "Regular Expression Denial of Service in Addressable templates" read more on the original package repository [addressable](https://github.com/sporkmonger/addressable/security/advisories/GHSA-jxhc-q857-3j6g)